### PR TITLE
Reparer oppdaging av nynorsk språk i nettlesarar

### DIFF
--- a/wasm_test.html
+++ b/wasm_test.html
@@ -1044,7 +1044,7 @@ forKvart nummer i [1, 2, 3, 4, 5] {
                     lang = stored;
                 } else {
                     const userLang = navigator.language || "";
-                    lang = /^n[bo]/i.test(userLang) ? "nn" : "en";
+                    lang = /^n[nbo]/i.test(userLang) ? "nn" : "en";
                 }
                 setLanguage(lang);
             })();


### PR DESCRIPTION
I nettlesarar sett til nynorsk er navigator.language "nn-NO".

Denne koden syner òg behovet for brunost på alt, sånn at ein slepp urein kode som `navigator.language` når det openbert burde ha vore `vegvisar.språk`.